### PR TITLE
fix issue with live reloading & speed up bundling process

### DIFF
--- a/webpack.config.coffee
+++ b/webpack.config.coffee
@@ -28,7 +28,7 @@ module.exports =
       }
       {
         test: /\.jsx?$/
-        exclude: /^(node_modules|dist|scripts)/
+        include: /src\/javascripts/
         loader: "babel?stage=0"
       }
       {


### PR DESCRIPTION
The babel loader's exclude regex was not doing its job, so I think Webpack was scanning through node_modules to find .jsx files. This caused an error in the browser-side live reloading code when serving the site with 'webpack-dev-server --hot --inline'. Swapping the exclude for an include fixes the js error & speeds up the bundling process.

I think this is a similar issue: https://github.com/webpack/webpack-dev-server/issues/174
